### PR TITLE
FIx #10

### DIFF
--- a/src/class-lsq-register-block.php
+++ b/src/class-lsq-register-block.php
@@ -121,7 +121,7 @@ class LSQ_Register_Block {
 				$classes .= ' lemonsqueezy-button';
 			}
 
-			$block_content = str_replace( '<a class="wp-block-button__link">', '<a class="' . $classes . '" href="' . $purchase_link . '">', $block_content );
+			$block_content = str_replace( '<a class="wp-block-button__link wp-element-button">', '<a class="' . $classes . '" href="' . $purchase_link . '">', $block_content );
 		}
 		if ( isset( $block['blockName'] ) && 'lemonsqueezy/ls-button' === $block['blockName'] ) {
 			$args = wp_parse_args( $block['attrs'] );


### PR DESCRIPTION
The default button has additional class wp-element-button. Your replace does not take effect without this class.

However I want underline that there a better method manipulate block attributes with [Html tag processor](https://developer.wordpress.org/reference/classes/wp_html_tag_processor/)