### PR TITLE
Added variants to Button HOC and LS Button

### DIFF
--- a/src/blocks/ls-button/index.js
+++ b/src/blocks/ls-button/index.js
@@ -40,6 +40,10 @@ const attributes = {
     customData: {
         type: "array",
         default: []
+    },
+    variant: {
+        type: 'string',
+        default: ''
     }
 };
 
@@ -81,13 +85,13 @@ registerBlockType("lemonsqueezy/ls-button", {
     deprecated: [{
         attributes,
         save: ({ attributes }) => {
-            const { content, overlay, product  } = attributes;
+            const { content, overlay, product } = attributes;
             let link = product;
             let className = [
                 'wp-block-button__link',
             ];
 
-            if ( overlay ) {
+            if (overlay) {
                 className.push('lemonsqueezy-button');
                 link = product + "?embed=1";
             }
@@ -95,7 +99,7 @@ registerBlockType("lemonsqueezy/ls-button", {
             return (
                 <div className="wp-block-buttons">
                     <div className="wp-block-button">
-                        <a className={className.join( ' ')} href={link}>
+                        <a className={className.join(' ')} href={link}>
                             {content}
                         </a>
                     </div>
@@ -112,17 +116,17 @@ registerBlockType("lemonsqueezy/ls-button", {
             'wp-block-button__link',
         ];
 
-        if ( overlay ) {
+        if (overlay) {
             className.push('lemonsqueezy-button');
             link = product + "?embed=1";
         }
 
         if (textColor != undefined) {
-            className.push( getColorClassName('color', textColor) );
+            className.push(getColorClassName('color', textColor));
         }
 
         if (backgroundColor != undefined) {
-            className.push( getColorClassName('background-color', backgroundColor) );
+            className.push(getColorClassName('background-color', backgroundColor));
         }
 
         if (customTextColor != undefined) {
@@ -136,7 +140,7 @@ registerBlockType("lemonsqueezy/ls-button", {
         return (
             <div className="wp-block-buttons">
                 <div className="wp-block-button">
-                    <a style={divStyles} className={className.join( ' ')} href={link}>
+                    <a style={divStyles} className={className.join(' ')} href={link}>
                         {content}
                     </a>
                 </div>

--- a/src/class-lsq-register-block.php
+++ b/src/class-lsq-register-block.php
@@ -113,12 +113,11 @@ class LSQ_Register_Block {
 
 			// If overlay is activated we have to include the script and add parameter to URL.
 			if ( ! empty( $args['overlay'] ) ) {
-				wp_enqueue_script( 'lemonsqueezy-checkout', 'https://app.lemonsqueezy.com/js/checkout.js', array(), null, true );
+				wp_enqueue_script( 'lemonsqueezy-checkout', 'https://assets.lemonsqueezy.com/lemon.js', array(), null, true );
 			}
 
-			$purchase_link = $this->get_purchase_link( $args, $block );
-
 			$existing_href = $this->get_link_from_button( $block_content );
+			$purchase_link = $this->get_purchase_link( $args, $block );
 
 			if ( $existing_href ) {
 				$block_content = str_replace( 'href="' . $existing_href . '"', 'href="' . $purchase_link . '"', $block_content );
@@ -136,7 +135,7 @@ class LSQ_Register_Block {
 			$args = wp_parse_args( $block['attrs'] );
 
 			if ( ! empty( $args['overlay'] ) ) {
-				wp_enqueue_script( 'lemonsqueezy-checkout', 'https://app.lemonsqueezy.com/js/checkout.js', array(), null, true );
+				wp_enqueue_script( 'lemonsqueezy-checkout', 'https://assets.lemonsqueezy.com/lemon.js', array(), null, true );
 			}
 
 			$existing_href = $this->get_link_from_button( $block_content );
@@ -154,11 +153,19 @@ class LSQ_Register_Block {
 	}
 
 	protected function get_purchase_link( $args, $block ) {
+		// If there's no product, abort.
 		if ( empty( $args['product'] ) ) {
 			return false;
 		}
 
-		$link = $args['product'];
+		// If variant set, create link with variant, or default to product link.
+		if( ! empty($args['variant']) ) {
+			$variant = $args['variant'];
+			$store_url = explode('/checkout/buy/', $args['product'] )[0];
+			$link = "$store_url/checkout/buy/$variant";
+		} else {
+			$link = $args['product'];
+		}
 
 		if ( ! empty( $args['overlay'] ) && $args['overlay'] ) {
 			$link = add_query_arg( 'embed', '1', $link );


### PR DESCRIPTION
Added variants selection to Button and LS Button blocks.
Variants selection enables to pre-select the variant in checkout page or checkout overlay modal.

To achieve this following changes have been done:
- in `src/class-lsq-rest-controller.php`  - added new route to LSQ_Rest_Controller class - "variants" to make new request to https://api.lemonsqueezy.com/v1/products/1/variants
- in `src/class-lsq-register-block.php` - changed purchase link from product to variant in `get_purchase_link` method. Since the product LS REST API request always returns variants (there is a "Default" variant even for product without created variants). For the checkout link the variant 'slug' property is used. The product link is still preserved as a fallback.
- in `src/blocks/button/index.js` , `src/blocks/ls-button/edit.js` and `src/blocks/ls-button/index.js` - added variant attribute, and variant selection control. Product variants load when product changes, respectively.

<img width="1207" alt="Editor options with variants" src="https://github.com/user-attachments/assets/8546dc89-d4c4-4c7d-862b-7d1b90de4f4f" />
<img width="508" alt="Pre-selected variant in checkout overlay" src="https://github.com/user-attachments/assets/0164534e-38b6-4afa-a155-217cd9f10b7c" />